### PR TITLE
Add Clement interpolation on domain interior

### DIFF
--- a/adapt_common/__init__.py
+++ b/adapt_common/__init__.py
@@ -2,4 +2,5 @@ from adapt_common.mesh import *  # noqa
 from adapt_common.norms import *  # noqa
 from adapt_common.recovery import *  # noqa
 from adapt_common.reduction import *  # noqa
+from adapt_common.transfer import *  # noqa
 from adapt_common.utility import *  # noqa

--- a/adapt_common/__init__.py
+++ b/adapt_common/__init__.py
@@ -1,3 +1,4 @@
+from adapt_common.mesh import *  # noqa
 from adapt_common.norms import *  # noqa
 from adapt_common.recovery import *  # noqa
 from adapt_common.reduction import *  # noqa

--- a/adapt_common/mesh.py
+++ b/adapt_common/mesh.py
@@ -7,7 +7,6 @@ __all__ = ["cell_volume", "patch_volume"]
 
 
 # TODO: Upstream as a cached_property of MeshGeometry in Firedrake
-# TODO: Write unit tests
 def cell_volume(mesh):
     """Interpolate a mesh's cell volume in :math:`P^0` space.
 
@@ -23,7 +22,6 @@ def cell_volume(mesh):
 
 
 # TODO: Upstream as a cached_property of MeshGeometry in Firedrake
-# TODO: Write unit tests
 def patch_volume(mesh):
     """Sum the volumes of cells neighbouring a vertex in :math:`P^1` space.
 

--- a/adapt_common/mesh.py
+++ b/adapt_common/mesh.py
@@ -6,7 +6,7 @@ import ufl
 __all__ = ["cell_volume", "patch_volume"]
 
 
-# TODO: Upstream as a cached_property of MeshGeometry in Firedrake
+# TODO: Upstream as a cached_property of MeshGeometry in Firedrake (#17)
 def cell_volume(mesh):
     """Interpolate a mesh's cell volume in :math:`P^0` space.
 
@@ -21,7 +21,7 @@ def cell_volume(mesh):
     return volume.interpolate(ufl.CellVolume(mesh))
 
 
-# TODO: Upstream as a cached_property of MeshGeometry in Firedrake
+# TODO: Upstream as a cached_property of MeshGeometry in Firedrake (#17)
 def patch_volume(mesh):
     """Sum the volumes of cells neighbouring a vertex in :math:`P^1` space.
 

--- a/adapt_common/mesh.py
+++ b/adapt_common/mesh.py
@@ -1,0 +1,40 @@
+"""Module containing mesh volume properties."""
+
+import firedrake as fd
+import ufl
+
+__all__ = ["cell_volume", "patch_volume"]
+
+
+# TODO: Upstream as a cached_property of MeshGeometry in Firedrake
+# TODO: Write unit tests
+def cell_volume(mesh):
+    """Interpolate a mesh's cell volume in :math:`P^0` space.
+
+    This is computed by interpolating the UFL :class:`~.CellVolume` for the mesh.
+
+    :arg mesh: the mesh to compute cell volumes for
+    :type mesh: :class:`firedrake.mesh.MeshGeometry`
+    :return: the cell volume Function
+    :rtype: :class:`firedrake.function.Function`
+    """
+    volume = fd.Function(fd.FunctionSpace(mesh, "Discontinuous Lagrange", 0))
+    return volume.interpolate(ufl.CellVolume(mesh))
+
+
+# TODO: Upstream as a cached_property of MeshGeometry in Firedrake
+# TODO: Write unit tests
+def patch_volume(mesh):
+    """Sum the volumes of cells neighbouring a vertex in :math:`P^1` space.
+
+    :arg mesh: the mesh to compute sums of cell volumes for
+    :type mesh: :class:`firedrake.mesh.MeshGeometry`
+    :return: the patch volume Function
+    :rtype: :class:`firedrake.function.Function`
+    """
+    patch_vol = fd.Function(fd.FunctionSpace(mesh, "Lagrange", 1))
+    domain = "{[i]: 0 <= i < patch.dofs}"
+    instructions = "patch[i] = patch[i] + vol[0]"
+    keys = {"vol": (cell_volume(mesh), fd.READ), "patch": (patch_vol, fd.RW)}
+    fd.par_loop((domain, instructions), ufl.dx(domain=mesh), keys)
+    return patch_vol

--- a/adapt_common/transfer.py
+++ b/adapt_common/transfer.py
@@ -1,0 +1,152 @@
+"""Module containing functions for transferring fields between function spaces."""
+
+import firedrake as fd
+import ufl
+from firedrake.petsc import PETSc
+
+from adapt_common.mesh import cell_volume, patch_volume
+from adapt_common.utility import (
+    cofunction2function,
+    function2cofunction,
+    get_function_space,
+)
+
+__all__ = ["clement_interpolant"]
+
+
+def _process_source(source):
+    """Process and validate the source function.
+
+    :arg source: the source function or cofunction
+    :type source: :class:`firedrake.function.Function` or
+        :class:`firedrake.cofunction.Cofunction`
+    :return: the source function space
+    :rtype: :class:`firedrake.functionspace.FunctionSpace`
+    """
+    if isinstance(source, fd.Cofunction):
+        Vs = source.function_space().dual()
+    elif isinstance(source, fd.Function):
+        Vs = source.function_space()
+    else:
+        type_err = f"Expected Cofunction or Function, got '{type(source)}'."
+        raise TypeError(type_err)
+
+    element = Vs.ufl_element()
+    if not (element.family() == "Discontinuous Lagrange" and element.degree() == 0):
+        val_err = "Source function provided must be from a P0 space."
+        raise ValueError(val_err)
+    return Vs
+
+
+def _process_target(source_space, target):
+    """Process and validate the target function or function space.
+
+    When `target` is None, the target's shape is inferred from the source space.
+
+    :arg source_space: the function space used for the source function
+    :type source_space: :class:`firedrake.functionspaceimpl.FunctionSpace`
+    :arg target: the target function, function space, cofunction, dual space, or None
+    :type target: :class:`firedrake.function.Function`,
+        :class:`firedrake.functionspaceimpl.FunctionSpace`,
+        :class:`firedrake.cofunction.Counction`,
+        :class:`firedrake.functionspaceimpl.FiredrakeDualSpace`, or None
+    :return: the target function and whether the user requested a cofunction target
+    :rtype: tuple[:class:`firedrake.function.Function`, bool]
+    """
+    is_cofunction = False
+    rank = len(source_space.value_shape)
+    mesh = source_space.mesh()
+
+    if isinstance(target, fd.Function):
+        Vt = target.function_space()
+    elif isinstance(target, fd.Cofunction):
+        target = cofunction2function(target)
+        Vt = target.function_space()
+        is_cofunction = True
+    elif isinstance(target, fd.functionspaceimpl.FiredrakeDualSpace):
+        target = fd.Function(target.dual())
+        Vt = target.function_space()
+        is_cofunction = True
+    elif isinstance(target, fd.functionspaceimpl.WithGeometry):
+        target = fd.Function(target)
+        Vt = target.function_space()
+    elif target is None:
+        Vt = get_function_space(mesh, "CG", 1, source_space.value_shape)
+        target = fd.Function(Vt)
+    else:
+        type_err = f"Unexpected target type '{type(target)}'."
+        raise TypeError(type_err)
+
+    # Validate that Vt is a P1 Lagrange space
+    element = Vt.ufl_element()
+    if not (element.family() == "Lagrange" and element.degree() == 1):
+        val_err = "Target space provided must be P1."
+        raise ValueError(val_err)
+
+    # Validate rank consistency
+    value_shape = getattr(Vt, "value_shape", ())
+    if rank != len(value_shape):
+        val_err = f"Rank-{rank} input inconsistent with target space."
+        raise ValueError(val_err)
+
+    # Ensure meshes match
+    if Vt.mesh() != mesh:
+        val_err = "Target function mesh inconsistent with source function mesh."
+        raise ValueError(val_err)
+
+    return target, is_cofunction
+
+
+@PETSc.Log.EventDecorator()
+def clement_interpolant(source, target=None):
+    r"""Compute the Clement interpolant of a :math:`\mathbb P0` source field.
+
+    i.e. take the volume average over neighbouring cells at each vertex. See
+    :cite:`Clement:1975`.
+
+    When `target` is None, the target's shape is inferred from the source space. If the
+    user requested a dual/cofunction target, a Cofunction will be returned; otherwise a
+    Function is returned.
+
+    :arg source: the :math:`\mathbb P0` source field or dual equivalent
+    :type source: :class:`firedrake.function.Function` or
+        :class:`firedrake.cofunction.Cofunction`
+    :arg target: the target function, function space, cofunction, dual space, or None
+    :type target: :class:`firedrake.function.Function`,
+        :class:`firedrake.functionspaceimpl.FunctionSpace`,
+        :class:`firedrake.cofunction.Counction`,
+        :class:`firedrake.functionspaceimpl.FiredrakeDualSpace`, or None
+    :return: the interpolated :math:`\mathbb P1` field
+    :rtype: :class:`firedrake.function.Function` or
+        :class:`firedrake.cofunction.Cofunction`
+    """
+    if isinstance(source, fd.Cofunction):
+        source = cofunction2function(source)
+    Vs = _process_source(source)
+    mesh = Vs.mesh()
+    target, is_cofunction = _process_target(Vs, target)
+
+    # Take the weighted average of the source function over the neighbouring cells
+    block_size = getattr(Vs, "block_size", 1)
+    domain = f"{{[i, j]: 0 <= i < out.dofs and 0 <= j < {block_size}}}"
+    instructions = "out[i, j] = out[i, j] + vol[0] * f[0, j]"
+    keys = {
+        "f": (source, fd.READ),
+        "vol": (cell_volume(mesh), fd.READ),
+        "out": (target, fd.RW),
+    }
+    fd.par_loop((domain, instructions), ufl.dx(domain=mesh), keys)
+
+    # Divide by the volume of the patch of neighbouring cells
+    domain = f"{{[j]: 0 <= j < {block_size}}}"
+    instructions = "out[0, j] = out[0, j] / patch[0]"
+    keys = {
+        "patch": (patch_volume(mesh), fd.READ),
+        "out": (target, fd.RW),
+    }
+    fd.par_loop((domain, instructions), fd.parloops.direct, keys)
+
+    # Map back to Cofunction, if one is requested or was passed originally
+    if is_cofunction:
+        return function2cofunction(target)
+    return target

--- a/adapt_common/utility.py
+++ b/adapt_common/utility.py
@@ -97,8 +97,18 @@ def get_function_space(mesh, family, degree, shape):
 
     For tensor spaces (rank > 1), if `shape` isn't provided then it defaults to
     the mesh topological dimension in each direction.
+
+    :arg mesh: mesh to build the function space on
+    :type mesh: :class:`firedrake.mesh.MeshGeometry`
+    :arg family: finite element family
+    :type family: str
+    :arg degree: finite element degree
+    :type degree: int
+    :arg shape: tensor shape
+    :type shape: tuple[int]
+    :return: the function space
+    :rtype: :class:`firedrake.functionspaceimpl.WithGeometry`
     """
-    # TODO: Args docstring
     if len(shape) == 0:
         return fd.FunctionSpace(mesh, family, degree)
     elif len(shape) == 1:

--- a/adapt_common/utility.py
+++ b/adapt_common/utility.py
@@ -88,6 +88,26 @@ def assemble_mass_matrix(space, norm_type="L2", lumped=False):
         return mass_matrix.createDiagonal(x)
 
 
+def get_function_space(mesh, family, degree, shape):
+    """Construct a function space given a mesh, element family, degree, and shape.
+
+    For vector (rank-1) spaces, the dimension is deduced from the first entry of
+    `shape`. If it's not provided then it's deduced from the mesh topological
+    dimension.
+
+    For tensor spaces (rank > 1), if `shape` isn't provided then it defaults to
+    the mesh topological dimension in each direction.
+    """
+    # TODO: Args docstring
+    if len(shape) == 0:
+        return fd.FunctionSpace(mesh, family, degree)
+    elif len(shape) == 1:
+        dim = mesh.topological_dimension() if shape is None else shape[0]
+        return fd.VectorFunctionSpace(mesh, family, degree, dim=dim)
+    else:
+        return fd.TensorFunctionSpace(mesh, family, degree, shape=shape)
+
+
 def cofunction2function(cofunc):
     """Convert a Cofunction into a Function.
 

--- a/test/test_mesh.py
+++ b/test/test_mesh.py
@@ -1,0 +1,36 @@
+"""Test the utilities from the mesh module."""
+
+import firedrake as fd
+import numpy as np
+import pytest
+
+from adapt_common.mesh import cell_volume
+
+
+@pytest.fixture
+def n():
+    """Set number of elements in each direction."""
+    return 5
+
+
+@pytest.fixture(params=[1, 2, 3], ids=["1D", "2D", "3D"])
+def topological_dimension(request):
+    """Set the topological dimension."""
+    return request.param
+
+
+@pytest.fixture
+def uniform_mesh(n, topological_dimension):
+    """Create a uniform unit simplex mesh with n elements in each direction."""
+    return {
+        1: fd.UnitIntervalMesh(n),
+        2: fd.UnitSquareMesh(n, n),
+        3: fd.UnitCubeMesh(n, n, n),
+    }[topological_dimension]
+
+
+def test_cell_volume_uniform_mesh(uniform_mesh):
+    """Test that the cell volume of a uniform mesh is indeed uniform."""
+    volume = cell_volume(uniform_mesh)
+    expected = 1.0 / uniform_mesh.num_cells()
+    np.testing.assert_almost_equal(volume.dat.data, expected)

--- a/test/test_mesh.py
+++ b/test/test_mesh.py
@@ -4,13 +4,13 @@ import firedrake as fd
 import numpy as np
 import pytest
 
-from adapt_common.mesh import cell_volume
+from adapt_common.mesh import cell_volume, patch_volume
 
 
 @pytest.fixture
 def n():
-    """Set number of elements in each direction."""
-    return 5
+    """Set number of cells in each direction."""
+    return 2
 
 
 @pytest.fixture(params=[1, 2, 3], ids=["1D", "2D", "3D"])
@@ -21,12 +21,71 @@ def topological_dimension(request):
 
 @pytest.fixture
 def uniform_mesh(n, topological_dimension):
-    """Create a uniform unit simplex mesh with n elements in each direction."""
+    """Create a uniform unit hypercube mesh with n cells in each direction."""
     return {
         1: fd.UnitIntervalMesh(n),
-        2: fd.UnitSquareMesh(n, n),
-        3: fd.UnitCubeMesh(n, n, n),
+        2: fd.UnitSquareMesh(n, n, reorder=False),
+        3: fd.UnitCubeMesh(n, n, n, reorder=False),
     }[topological_dimension]
+
+
+expected_coords_1d = np.array([0.0, 0.5, 1.0])
+
+expected_coords_2d = np.array(
+    [
+        [0.0, 0.0],
+        [0.0, 0.5],
+        [0.5, 0.0],
+        [0.5, 0.5],
+        [0.0, 1.0],
+        [0.5, 1.0],
+        [1.0, 0.0],
+        [1.0, 0.5],
+        [1.0, 1.0],
+    ],
+)
+
+expected_coords_3d = np.array(
+    [
+        [0.0, 0.0, 0.0],
+        [0.5, 0.0, 0.0],
+        [0.5, 0.5, 0.0],
+        [0.5, 0.5, 0.5],
+        [0.5, 0.0, 0.5],
+        [0.0, 0.0, 0.5],
+        [0.0, 0.5, 0.0],
+        [0.0, 0.5, 0.5],
+        [1.0, 0.0, 0.0],
+        [1.0, 0.5, 0.0],
+        [1.0, 0.5, 0.5],
+        [1.0, 0.0, 0.5],
+        [0.5, 1.0, 0.0],
+        [0.5, 1.0, 0.5],
+        [0.0, 1.0, 0.0],
+        [0.0, 1.0, 0.5],
+        [1.0, 1.0, 0.0],
+        [1.0, 1.0, 0.5],
+        [0.5, 0.5, 1.0],
+        [0.5, 0.0, 1.0],
+        [0.0, 0.0, 1.0],
+        [0.0, 0.5, 1.0],
+        [1.0, 0.5, 1.0],
+        [1.0, 0.0, 1.0],
+        [0.5, 1.0, 1.0],
+        [0.0, 1.0, 1.0],
+        [1.0, 1.0, 1.0],
+    ]
+)
+
+
+def test_mesh_coordinates(topological_dimension, uniform_mesh):
+    """Test that the mesh coordinates take expected values under reorder=False."""
+    expected_coords = {
+        1: expected_coords_1d,
+        2: expected_coords_2d,
+        3: expected_coords_3d,
+    }[topological_dimension]
+    np.testing.assert_almost_equal(uniform_mesh.coordinates.dat.data, expected_coords)
 
 
 def test_cell_volume_uniform_mesh(uniform_mesh):
@@ -34,3 +93,18 @@ def test_cell_volume_uniform_mesh(uniform_mesh):
     volume = cell_volume(uniform_mesh)
     expected = 1.0 / uniform_mesh.num_cells()
     np.testing.assert_almost_equal(volume.dat.data, expected)
+
+
+def test_patch_volume_uniform_mesh(topological_dimension, uniform_mesh):
+    """Test that the patch volumes of a uniform mesh takes expected values."""
+    patch_vol = patch_volume(uniform_mesh)
+    cell_vol = 1.0 / uniform_mesh.num_cells()
+    # fmt: off
+    num_neighbouring_cells = {
+        1: [1, 2, 1],
+        2: [1, 3, 3, 6, 2, 3, 2, 3, 1],
+        3: [6, 8, 12, 24, 12, 8, 8, 12, 2, 4, 12, 4, 4, 12, 2, 4, 2, 8, 12, 4, 2, 4, 8, 2, 8, 2, 6],  # noqa
+    }[topological_dimension]
+    # fmt: on
+    expected = np.array(num_neighbouring_cells) * cell_vol
+    np.testing.assert_almost_equal(patch_vol.dat.data, expected)

--- a/test/test_transfer_clement.py
+++ b/test/test_transfer_clement.py
@@ -1,0 +1,152 @@
+"""Test the Clement interpolation functionality from the transfer module."""
+
+import firedrake as fd
+import numpy as np
+import pytest
+import ufl
+
+from adapt_common.transfer import clement_interpolant
+from adapt_common.utility import cofunction2function, get_function_space
+
+
+@pytest.fixture
+def n():
+    """Set number of elements in each direction."""
+    return 5
+
+
+@pytest.fixture(params=[1, 2, 3], ids=["1D", "2D", "3D"])
+def topological_dimension(request):
+    """Set the topological dimension."""
+    return request.param
+
+
+@pytest.fixture(
+    params=[(), (1,), (2,), (3,), (1, 1), (1, 2), (2, 2), (2, 3), (3, 3)],
+    ids=[
+        "scalar",
+        "1vector",
+        "2vector",
+        "3vector",
+        "1x1tensor",
+        "1x2tensor",
+        "2x2tensor",
+        "2x3tensor",
+        "3x3tensor",
+    ],
+)
+def shape(request):
+    """Set the tensor shape."""
+    return request.param
+
+
+@pytest.fixture
+def uniform_mesh(n, topological_dimension):
+    """Create a uniform unit simplex mesh with n elements in each direction."""
+    return {
+        1: fd.UnitIntervalMesh(n),
+        2: fd.UnitSquareMesh(n, n),
+        3: fd.UnitCubeMesh(n, n, n),
+    }[topological_dimension]
+
+
+@pytest.fixture
+def P0(uniform_mesh, shape):
+    """Create a P0 function space of a given shape on the uniform mesh."""
+    return get_function_space(uniform_mesh, "DG", 0, shape)
+
+
+@pytest.fixture
+def P1(uniform_mesh, shape):
+    """Create a P1 function space of a given shape on the uniform mesh."""
+    return get_function_space(uniform_mesh, "CG", 1, shape)
+
+
+@pytest.fixture
+def expression(uniform_mesh, topological_dimension, shape, P1):
+    """Expression function for testing based on tensor shape."""
+    x = fd.SpatialCoordinate(uniform_mesh)
+    if len(shape) == 0:
+        return sum(x)
+    elif len(shape) == 1:
+        dim = shape[0]
+        return ufl.as_vector(
+            x if dim == topological_dimension else [x[0] for _ in range(dim)]
+        )
+    rows = [
+        fd.Constant(tuple(range(i + 1, i + 1 + topological_dimension)))
+        for i in range(P1.block_size)
+    ]
+    return ufl.as_tensor(np.reshape([ufl.dot(row, x) for row in rows], shape))
+
+
+def test_source_type_error():
+    """Test that providing an invalid source type raises a TypeError."""
+    type_err = (
+        "Expected Cofunction or Function, got '<class 'firedrake.constant.Constant'>'."
+    )
+    with pytest.raises(TypeError, match=type_err):
+        clement_interpolant(fd.Constant(0.0))
+
+
+def test_source_space_error(uniform_mesh):
+    """Test that providing a non-P0 source function raises a ValueError."""
+    shape = ()
+    fs = get_function_space(uniform_mesh, "CG", 1, shape)
+    val_err = "Source function provided must be from a P0 space."
+    with pytest.raises(ValueError, match=val_err):
+        clement_interpolant(fd.Function(fs))
+
+
+def test_target_function_space_error(uniform_mesh):
+    """Test that providing a non-P1 target space raises a ValueError."""
+    shape = ()
+    fs = get_function_space(uniform_mesh, "DG", 0, shape)
+    val_err = "Target space provided must be P1."
+    with pytest.raises(ValueError, match=val_err):
+        clement_interpolant(fd.Function(fs), target=fs)
+
+
+def test_cofunction_dual_target_function_space(P0, P1):
+    """Test that Clement interpolation works with dual spaces."""
+    source = fd.Cofunction(P0.dual())
+    source.dat.data[:] = 1.0
+    target = clement_interpolant(source, target=P1.dual())
+    assert isinstance(target, fd.Cofunction)
+    target_function = cofunction2function(target)
+
+    # Account for the fact that the Clement interpolant breaks down at domain boundaries
+    expected = fd.Function(P1).assign(1.0)
+    fd.DirichletBC(P1, expected, "on_boundary").apply(target_function)
+
+    np.testing.assert_almost_equal(target_function.dat.data, expected.dat.data)
+
+
+def test_cofunction_primal_target_function_space(P0, P1):
+    """Test that Clement interpolation works with primal target spaces."""
+    source = fd.Cofunction(P0.dual())
+    source.dat.data[:] = 1.0
+    target = clement_interpolant(source, target=P1)
+    assert isinstance(target, fd.Function)
+
+    # Account for the fact that the Clement interpolant breaks down at domain boundaries
+    expected = fd.Function(P1).assign(1.0)
+    fd.DirichletBC(P1, expected, "on_boundary").apply(target)
+
+    np.testing.assert_almost_equal(target.dat.data, expected.dat.data)
+
+
+def test_volume_average(P0, P1, expression):
+    """Test Clement interpolation in the interior of a 2D domain."""
+    exact = expression
+    source_space = P0
+    source = fd.Function(source_space).project(exact)
+    target = clement_interpolant(source)
+    target_function_space = P1
+    expected = fd.Function(target_function_space).interpolate(exact)
+
+    # Account for the fact that the Clement interpolant breaks down at domain boundaries
+    bc = fd.DirichletBC(target_function_space, expected, "on_boundary")
+    bc.apply(target)
+
+    np.testing.assert_almost_equal(target.dat.data, expected.dat.data)


### PR DESCRIPTION
Closes #10.

This PR ports the interior Clement interpolation functionality of Animate over to adapt_common.

Edit: I'll do the boundary case in a follow-up PR.

## Checklist

- [x] `get_function_space` util
- [x] Clement interpolant
- [x] Supporting mesh utils
- [x] Tests for Clement
- [x] Tests for mesh utils
- [x] Docstring for `get_function_space`
- [x] Open issue for upstreaming and link in code